### PR TITLE
Reset error state after mutation

### DIFF
--- a/packages/react/src/components/ConsumerControl.tsx
+++ b/packages/react/src/components/ConsumerControl.tsx
@@ -46,7 +46,7 @@ const ConsumerControl = ({
     setQueryError(undefined);
   }, [keyRollMutation.isLoading]);
 
-  const handleError = (error: unknown) => {
+  const handleMutationComplete = (error: unknown) => {
     if (!error) {
       setQueryError(undefined);
       return;
@@ -184,7 +184,7 @@ const ConsumerControl = ({
       <div className="bg-white rounded-b-lg p-4">
         {consumer.apiKeys.map((k) => (
           <KeyControl
-            onError={handleError}
+            onMutationComplete={handleMutationComplete}
             key={k.id}
             apiKey={k}
             consumerName={consumer.name}

--- a/packages/react/src/components/KeyControl.tsx
+++ b/packages/react/src/components/KeyControl.tsx
@@ -16,7 +16,7 @@ import { useQueryEngineContext } from "../useQueryEngineContext";
 interface KeyControlProps {
   consumerName: string;
   apiKey: ApiKey;
-  onError: (error: unknown) => void;
+  onMutationComplete: (error: unknown) => void;
 }
 
 dayjs.extend(relativeTime);
@@ -33,7 +33,11 @@ function mask(value: string, mask: boolean) {
   return maskedPart + lastEightChars;
 }
 
-const KeyControl = ({ apiKey, consumerName, onError }: KeyControlProps) => {
+const KeyControl = ({
+  apiKey,
+  consumerName,
+  onMutationComplete,
+}: KeyControlProps) => {
   const [masked, setMasked] = useState<boolean>(true);
   const [copied, setCopied] = useState<boolean>(false);
   const { useDeleteKeyMutation } = useQueryEngineContext();
@@ -48,7 +52,7 @@ const KeyControl = ({ apiKey, consumerName, onError }: KeyControlProps) => {
   }
 
   useEffect(() => {
-    onError(deleteKeyMutation.error);
+    onMutationComplete(deleteKeyMutation.error);
     // We use the isLoading flag here to reset the error state whenever the
     // mutation is triggered
   }, [deleteKeyMutation.isLoading]);


### PR DESCRIPTION
## Summary

As title. If you have an error, the next successful mutation will reset the UI.

## Preview


https://github.com/zuplo/api-key-manager/assets/11202679/ae8ca69d-c4a7-4af1-a6cf-b5d6dfa1a27e

