### PR TITLE
Fix api key overflow

### DIFF
--- a/packages/react/src/components/KeyControl.tsx
+++ b/packages/react/src/components/KeyControl.tsx
@@ -69,7 +69,10 @@ const KeyControl = ({
   return (
     <div>
       <div className="flex flex-row justify-between items-center">
-        <span className="font-mono text-ellipsis overflow-hidden py-2 mr-2 text-zinc-800">
+        <span
+          title={masked ? undefined : apiKey.key}
+          className="font-mono text-ellipsis overflow-hidden py-2 mr-2 text-zinc-800"
+        >
           {mask(apiKey.key, masked)}
         </span>
         <div className="flex gap-x-1 justify-end text-zinc-500">


### PR DESCRIPTION
## Summary

Fix key overflow when the width of the component is too small

## Preview

![image](https://github.com/zuplo/api-key-manager/assets/11202679/c64584ea-fcae-4094-8451-c91d601f88e1)
