### PR TITLE
Fix backgrounds in themes

### DIFF
--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -31,3 +31,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env.local

--- a/packages/react/src/components/ApiKeyManager.tsx
+++ b/packages/react/src/components/ApiKeyManager.tsx
@@ -7,14 +7,19 @@ import { XCircleIcon } from "./icons";
 import styles from "./ApiKeyManager.module.css";
 import { useEffect } from "react";
 
+type ThemeOptions = "light" | "dark" | "system";
+type Theme = "light" | "dark";
 interface Props {
   menuItems?: MenuItem[];
-  theme?: "light" | "dark";
+  /**
+   * @default "light"
+   */
+  theme?: ThemeOptions;
   provider: ApiKeyManagerProvider;
   showIsLoading?: boolean;
 }
 
-const getSystemDefaultThemePreference = (): "dark" | "light" => {
+const getSystemDefaultThemePreference = (): Theme => {
   if (
     typeof window !== "undefined" &&
     window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -24,12 +29,22 @@ const getSystemDefaultThemePreference = (): "dark" | "light" => {
   return "light";
 };
 
-function ApiKeyManager({ provider, menuItems, showIsLoading, theme }: Props) {
+const getTheme = (theme: ThemeOptions): Theme => {
+  if (theme === "system") {
+    return getSystemDefaultThemePreference();
+  }
+  return theme;
+};
+
+function ApiKeyManager({
+  provider,
+  menuItems,
+  showIsLoading,
+  theme = "light",
+}: Props) {
   const queryEngine = useProviderQueryEngine(provider);
   const query = queryEngine.useMyConsumersQuery();
-  const themeStyle = `zp-key-manager--${
-    theme ?? getSystemDefaultThemePreference()
-  }`;
+  const themeStyle = `zp-key-manager--${getTheme(theme)}`;
   useEffect(() => {
     const handle = provider.registerOnRefresh(() => {
       queryEngine.refreshMyConsumers();

--- a/packages/react/src/components/ConsumerControl.module.css
+++ b/packages/react/src/components/ConsumerControl.module.css
@@ -1,10 +1,6 @@
 /* ConsumerControl.module.css */
 .consumer-control-container {
-  @apply rounded-lg bg-slate-50 border-zinc-200  dark:border-none border mb-5 selection:dark:text-zinc-900 selection:dark:bg-white;
-}
-
-:is(.dark .consumer-control-container) {
-  background-color: #4f566b;
+  @apply rounded-lg bg-slate-50 dark:bg-[#4f566b] border-zinc-200  dark:border-none border mb-5 selection:dark:text-zinc-900 selection:dark:bg-white;
 }
 
 .consumer-control-header {
@@ -100,11 +96,7 @@
 }
 
 .consumer-control-content {
-  @apply bg-white rounded-b-lg p-4;
-}
-
-.dark .consumer-control-content {
-  background-color: #2a2f45;
+  @apply bg-white rounded-b-lg p-4 dark:bg-[#2a2f45];
 }
 
 .consumer-control-key-control {

--- a/packages/react/src/components/ConsumerLoading.module.css
+++ b/packages/react/src/components/ConsumerLoading.module.css
@@ -1,9 +1,5 @@
 .consumer-loading-container {
-  @apply rounded-lg bg-slate-50 border-zinc-200 dark:border-none border mb-5;
-}
-
-.dark .consumer-loading-container {
-  background-color: #4f566b;
+  @apply rounded-lg bg-slate-50 dark:bg-[#4f566b] border-zinc-200 dark:border-none border mb-5;
 }
 
 .consumer-loading-header {
@@ -23,11 +19,7 @@
 }
 
 .consumer-loading-content {
-  @apply bg-white flex flex-col rounded-b-lg p-4 py-2;
-}
-
-.dark .consumer-loading-content {
-  background-color: #2a2f45;
+  @apply bg-white dark:bg-[#2a2f45] flex flex-col rounded-b-lg p-4 py-2;
 }
 
 .key-loading-container {

--- a/packages/react/src/components/SimpleMenu.module.css
+++ b/packages/react/src/components/SimpleMenu.module.css
@@ -9,11 +9,7 @@
 }
 
 .simple-menu-dialog {
-  @apply absolute top-0 right-0 z-50 shadow-md rounded bg-white;
-}
-
-.dark .simple-menu-dialog {
-  background-color: #1a1f36;
+  @apply absolute top-0 right-0 z-50 shadow-md rounded bg-white dark:bg-[#1a1f36];
 }
 
 .simple-menu-item-button {

--- a/packages/react/tailwind.config.js
+++ b/packages/react/tailwind.config.js
@@ -9,7 +9,7 @@ export default {
         // Instead use selectors and values directly
         // Ex. for dark mode use
         /**
-         * .dark .simple-menu-dialog {
+         * .dark .simple-menu-dialog:hover {
          *     background-color: #1a1f36;
          *  }
          */


### PR DESCRIPTION
## Summary

- Changing default theme to `light`
- Adding a `system` option to match the system theme
- Fixing some styles to use tailwind's `dark` in case Tailwind's`darkmode: class` setting is being used

Unfortunately the `hover` versions will not automatically respect the `darkmode:class` setting, but the user can just provide the `theme` value to override this anyways