### PR TITLE
Roll keys fix

### DIFF
--- a/packages/react/src/components/ConsumerControl.tsx
+++ b/packages/react/src/components/ConsumerControl.tsx
@@ -111,11 +111,11 @@ const ConsumerControl = ({
     icon: PencilSquareIcon({}),
   };
 
+  // You can't roll keys if there are no keys to roll
+  const numRollableKeys = consumer.apiKeys.filter((k) => !k.expiresOn).length;
+  const enableRollKeys = numRollableKeys > 0;
   const rollKeysMenuItem: MenuItem = {
-    label:
-      consumer.apiKeys.filter((k) => !k.expiresOn).length > 1
-        ? "Roll keys"
-        : "Roll key",
+    label: numRollableKeys > 1 ? "Roll keys" : "Roll key",
     action: handleRollKey,
     icon: ArrowPathIcon({}),
   };
@@ -126,8 +126,10 @@ const ConsumerControl = ({
     icon: TrashIcon({}),
   };
 
-  const initialMenuItems = [editLabelMenuItem, rollKeysMenuItem];
-
+  const initialMenuItems: MenuItem[] = [editLabelMenuItem];
+  if (enableRollKeys) {
+    initialMenuItems.push(rollKeysMenuItem);
+  }
   if (enableDeleteConsumer) {
     initialMenuItems.push(deleteConsumerMenuItem);
   }


### PR DESCRIPTION
## Summary

Our API will error if you try to roll keys without having any keys to roll. I am not sure if the backend is correct in doing so, but we should avoid leading users down a path they don't need to go. You can only really get into this state if you are on an older project or using the API - so I assume you can get yourself out of it too and create a key via the API.