### PR TITLE
Fix property names

### DIFF
--- a/packages/react/src/components/icons.tsx
+++ b/packages/react/src/components/icons.tsx
@@ -213,14 +213,14 @@ export const PencilSquareIcon = (props: { className?: string }) => (
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
-    stroke-width="1.5"
+    strokeWidth="1.5"
     stroke="currentColor"
     className={styles["icon"]}
     {...props}
   >
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10"
     />
   </svg>
@@ -231,14 +231,14 @@ export const ArrowPathIcon = (props: { className?: string }) => (
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
-    stroke-width="1.5"
+    strokeWidth="1.5"
     stroke="currentColor"
     className={styles["icon"]}
     {...props}
   >
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
     />
   </svg>


### PR DESCRIPTION
## Summary

React gets mad if you use the `-`. The actual props are camel case. You get an error in the console

<img width="453" alt="image" src="https://github.com/zuplo/api-key-manager/assets/11202679/13e835af-0121-420a-8e9b-256bd5df4450">
